### PR TITLE
Fix table id when columns updated

### DIFF
--- a/protobuf-delta-lake-sink/src/main.rs
+++ b/protobuf-delta-lake-sink/src/main.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
 use anyhow::{anyhow, Context, Result};
 use chrono::{NaiveDateTime, Utc};
 use clap::Parser;
@@ -16,10 +21,6 @@ use file_store::Settings;
 use futures::stream::{self, StreamExt};
 use protobuf::CodedInputStream;
 use serde_json::Value;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
 pub use store::*;
 
 use crate::{
@@ -189,7 +190,8 @@ async fn main() -> Result<()> {
             vec!["date".to_string()],
             HashMap::new(),
         );
-        let meta = action::MetaData::try_from(metadata)?;
+        let mut meta = action::MetaData::try_from(metadata)?;
+        meta.id = table.get_metadata()?.id.clone();
         let actions = vec![Action::metaData(meta)];
         let storage = table.object_store();
         commit(storage.as_ref(), &actions, &table.state).await?;


### PR DESCRIPTION
We had to implement a hack to support schema evolution, as delta-rs didn't support it. Our hack overwrote the table id, a randomly generated uuid. This made subsequent spark streaming jobs angry because they would look at the table and see a new ID than what they were used to.